### PR TITLE
Add scaffold for ChatGPT data analysis MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+node_modules/
+.env
+uploads/
+worker/output/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# agentic
+# ChatGPT Data Analysis MVP
+
+This repository contains a minimal proof-of-concept web application that lets a user upload a CSV or XLSX file and ask questions about the data using ChatGPT.
+
+## Structure
+
+- **frontend/** – React interface for file upload and chat
+- **backend/** – Flask API for file parsing and ChatGPT requests
+- **worker/** – Dockerized Python sandbox for executing GPT generated code
+
+## Running Locally
+
+Set your OPENAI_API_KEY environment variable before running the backend.
+1. Start the worker service:
+   ```bash
+   cd worker
+   docker build -t data-worker .
+   docker run -p 8001:8001 data-worker
+   ```
+2. Install backend requirements and start the API:
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   python app.py
+   ```
+3. In another terminal start the React dev server:
+   ```bash
+   cd frontend
+   npm install
+   npm run start
+   ```
+
+Upload a CSV/XLSX file (≤10 MB) and start asking questions!

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,91 @@
+import os
+import tempfile
+from flask import Flask, request, jsonify, send_from_directory
+import pandas as pd
+import openai
+
+openai.api_key = os.environ.get("OPENAI_API_KEY")
+app = Flask(__name__)
+app.static_folder = "../frontend/public"
+app.config['UPLOAD_FOLDER'] = 'uploads'
+app.config['CHART_FOLDER'] = 'charts'
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+os.makedirs(app.config['CHART_FOLDER'], exist_ok=True)
+
+# Simple in-memory store for uploaded DataFrame
+DATAFRAME = None
+SCHEMA = None
+
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    global DATAFRAME, SCHEMA
+    file = request.files.get('file')
+    if not file:
+        return jsonify({'error': 'no file'}), 400
+    path = os.path.join(app.config['UPLOAD_FOLDER'], file.filename)
+    file.save(path)
+    if file.filename.lower().endswith('.xlsx'):
+        df = pd.read_excel(path)
+    else:
+        df = pd.read_csv(path)
+    DATAFRAME = df
+    SCHEMA = {c: str(df[c].dtype) for c in df.columns}
+    preview = df.head().to_dict(orient='records')
+    return jsonify({'preview': preview, 'schema': SCHEMA})
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    if DATAFRAME is None:
+        return jsonify({'error': 'no data uploaded'}), 400
+    data = request.get_json()
+    question = data.get('message')
+    if not question:
+        return jsonify({'error': 'no message'}), 400
+
+    system_prompt = (
+        "You are a data analyst. The user has uploaded a DataFrame with this schema:\n"
+        f"{SCHEMA}."
+        " Write Python pandas code (with matplotlib if needed) to answer the user's question."
+        " Return only code inside a Markdown code block.")
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": question}
+        ],
+        temperature=0
+    )
+    code = response['choices'][0]['message']['content']
+
+    result = run_code(code)
+    return jsonify(result)
+
+def run_code(code_block: str):
+    """Send code to worker for execution."""
+    import requests
+    # Expect code_block contains ```python ...```
+    if '```' in code_block:
+        code = code_block.split('```')[1]
+    else:
+        code = code_block
+    # Send to local worker
+    try:
+        resp = requests.post('http://localhost:8001/execute', json={
+            'code': code,
+            'schema': SCHEMA
+        }, timeout=10)
+        return resp.json()
+    except Exception as e:
+        return {'error': str(e)}
+
+@app.route('/charts/<path:name>')
+def get_chart(name):
+    return send_from_directory(app.config['CHART_FOLDER'], name)
+
+@app.route('/')
+def index():
+    return app.send_static_file('index.html')
+
+if __name__ == '__main__':
+    app.run(port=8000, debug=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+flask
+pandas
+openai
+requests

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "chatgpt-data-app",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "axios": "^1.0.0"
+  },
+  "scripts": {
+    "start": "parcel public/index.html --port 3000"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Data Chat</title>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="../src/index.js" type="module"></script>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+function App() {
+  const [file, setFile] = useState(null);
+  const [preview, setPreview] = useState(null);
+  const [schema, setSchema] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  const upload = async () => {
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await axios.post('/upload', formData);
+    setPreview(res.data.preview);
+    setSchema(res.data.schema);
+  };
+
+  const sendMessage = async () => {
+    const msg = { sender: 'user', text: input };
+    setMessages([...messages, msg]);
+    setInput('');
+    const res = await axios.post('/chat', { message: input });
+    setMessages(m => [...m, msg, { sender: 'bot', data: res.data }]);
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Data Chat</h1>
+      <input type="file" onChange={e => setFile(e.target.files[0])} />
+      <button onClick={upload}>Upload</button>
+      {preview && (
+        <div>
+          <h3>Preview</h3>
+          <pre>{JSON.stringify(preview, null, 2)}</pre>
+        </div>
+      )}
+      <div style={{ marginTop: 20 }}>
+        <input value={input} onChange={e => setInput(e.target.value)} />
+        <button onClick={sendMessage}>Send</button>
+      </div>
+      <div>
+        {messages.map((m, i) => (
+          <div key={i} style={{ margin: '10px 0' }}>
+            <b>{m.sender}:</b>{' '}
+            {m.text && <span>{m.text}</span>}
+            {m.data && (
+              <span>
+                {m.data.table && (
+                  <table border="1">
+                    <tbody>
+                      {m.data.table.map((row, ri) => (
+                        <tr key={ri}>
+                          {Object.values(row).map((cell, ci) => (
+                            <td key={ci}>{cell}</td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+                {m.data.image && <img src={m.data.image} alt="chart" />}
+                {m.data.error && <pre>{m.data.error}</pre>}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.9-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY worker.py ./
+CMD ["python", "worker.py"]

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -1,0 +1,3 @@
+flask
+pandas
+matplotlib

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1,0 +1,55 @@
+from flask import Flask, request, jsonify, send_from_directory
+import os
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import pandas as pd
+import resource
+import signal
+
+app = Flask(__name__)
+OUTPUT_DIR = os.environ.get('CHART_DIR', 'output')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+# Charts should be saved to OUTPUT_DIR and path stored in chart_path variable
+
+def limit_resources():
+    resource.setrlimit(resource.RLIMIT_CPU, (5, 5))
+    resource.setrlimit(resource.RLIMIT_AS, (512 * 1024 * 1024, 512 * 1024 * 1024))
+
+class TimeoutException(Exception):
+    pass
+
+def timeout_handler(signum, frame):
+    raise TimeoutException()
+
+@app.route('/execute', methods=['POST'])
+def execute_code():
+    payload = request.get_json()
+    code = payload.get('code')
+    global_vars = {'pd': pd, 'plt': plt, 'result': None, 'chart_path': None}
+    try:
+        signal.signal(signal.SIGALRM, timeout_handler)
+        signal.alarm(5)
+        limit_resources()
+        exec(code, global_vars)
+        signal.alarm(0)
+        resp = {}
+        if isinstance(global_vars.get('result'), pd.DataFrame):
+            resp['table'] = global_vars['result'].to_dict(orient='records')
+        chart_path = global_vars.get('chart_path')
+        if not chart_path and plt.get_fignums():
+            chart_path = os.path.join(OUTPUT_DIR, 'chart.png')
+            plt.savefig(chart_path)
+        if chart_path:
+            resp['image'] = f'/charts/{os.path.basename(chart_path)}'
+        return jsonify(resp)
+    except Exception as e:
+        return jsonify({'error': str(e)})
+
+@app.route('/charts/<path:name>')
+def send_chart(name):
+    return send_from_directory(OUTPUT_DIR, name)
+
+if __name__ == '__main__':
+    app.run(port=8001)


### PR DESCRIPTION
## Summary
- initialize repository with README and gitignore
- scaffold backend Flask server with upload and chat endpoints
- scaffold React frontend with file upload and chat UI
- add Dockerized Python worker to execute GPT-generated code safely
- include basic instructions for running the stack

## Testing
- `python -m py_compile backend/app.py worker/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68841358e6308321b8ffb1d3524a5b70